### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           COMMIT: ${{ github.SHA }}
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore